### PR TITLE
feat: add patient-specific entry modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,9 @@
                     <div class="card profile-card">
                         <div class="card__header">
                             <h3><i class="fas fa-flask"></i> Wyniki badań laboratoryjnych</h3>
+                            <button id="add-lab-result-btn" class="btn btn--primary btn--sm hidden">
+                                <i class="fas fa-plus"></i> Dodaj wynik
+                            </button>
                         </div>
                         <div class="card__body">
                             <div id="lab-results" class="lab-results"></div>
@@ -392,6 +395,40 @@
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn--primary">Dodaj komentarz</button>
+                    <button type="button" class="btn btn--outline modal-close">Anuluj</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div id="add-lab-result-modal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Dodaj wynik badania</h3>
+                <button class="modal-close">&times;</button>
+            </div>
+            <form id="add-lab-result-form">
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="lab-test-name" class="form-label">Nazwa badania</label>
+                        <input list="lab-test-suggestions" type="text" id="lab-test-name" class="form-control" required>
+                        <datalist id="lab-test-suggestions">
+                            <option value="Morfologia">
+                            <option value="Glukoza">
+                            <option value="Cholesterol">
+                        </datalist>
+                    </div>
+                    <div class="form-group">
+                        <label for="lab-result-date" class="form-label">Data</label>
+                        <input type="date" id="lab-result-date" class="form-control" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="lab-result-value" class="form-label">Wynik</label>
+                        <input type="text" id="lab-result-value" class="form-control" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn--primary">Zapisz</button>
                     <button type="button" class="btn btn--outline modal-close">Anuluj</button>
                 </div>
             </form>


### PR DESCRIPTION
## Summary
- add dedicated modals for medical records, comments, and lab results
- validate inputs and auto-focus between fields for quicker entry
- tie form submissions to the currently selected patient only

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6897942c41e8832ea93cbd18f02fac83