### PR TITLE
Add lab results import and filtering

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 // Prosty frontend korzystający z backendu Express
 let token = null;
+let currentPatientId = null;
 
 async function login(e) {
   e.preventDefault();
@@ -31,5 +32,60 @@ async function loadPatients() {
   if (!res.ok) return;
   const patients = await res.json();
   const grid = document.getElementById('patients-grid');
-  grid.innerHTML = patients.map(p => `<div class="patient-card">${p.first_name} ${p.last_name}</div>`).join('');
+  grid.innerHTML = patients
+    .map(p => `<div class="patient-card" data-id="${p.id}" data-name="${p.first_name} ${p.last_name}">${p.first_name} ${p.last_name}</div>`)
+    .join('');
+  const select = document.getElementById('import-patient-select');
+  select.innerHTML = '<option value="">Wybierz pacjenta</option>' +
+    patients.map(p => `<option value="${p.id}">${p.first_name} ${p.last_name}</option>`).join('');
+  document.querySelectorAll('.patient-card').forEach(card => {
+    card.addEventListener('click', () => {
+      currentPatientId = card.getAttribute('data-id');
+      document.getElementById('dashboard-section').classList.remove('active');
+      document.getElementById('patient-profile-section').classList.add('active');
+      document.getElementById('patient-name').textContent = card.getAttribute('data-name');
+      loadLabResults();
+    });
+  });
 }
+
+document.getElementById('back-to-dashboard').addEventListener('click', () => {
+  document.getElementById('patient-profile-section').classList.remove('active');
+  document.getElementById('dashboard-section').classList.add('active');
+});
+
+document.getElementById('import-lab-results').addEventListener('click', async () => {
+  const patientId = document.getElementById('import-patient-select').value;
+  const fileInput = document.getElementById('lab-file');
+  if (!patientId || fileInput.files.length === 0) return;
+  const formData = new FormData();
+  formData.append('patientId', patientId);
+  formData.append('file', fileInput.files[0]);
+  const res = await fetch('/api/lab-results/import', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${token}` },
+    body: formData
+  });
+  if (res.ok) {
+    fileInput.value = '';
+    alert('Plik zaimportowany');
+  }
+});
+
+async function loadLabResults() {
+  if (!currentPatientId) return;
+  const testName = document.getElementById('filter-test-name').value;
+  const from = document.getElementById('filter-from-date').value;
+  const to = document.getElementById('filter-to-date').value;
+  let url = `/api/lab-results?patientId=${currentPatientId}`;
+  if (testName) url += `&testName=${encodeURIComponent(testName)}`;
+  if (from) url += `&from=${from}`;
+  if (to) url += `&to=${to}`;
+  const res = await fetch(url, { headers: { 'Authorization': `Bearer ${token}` } });
+  if (!res.ok) return;
+  const results = await res.json();
+  const container = document.getElementById('lab-results');
+  container.innerHTML = results.map(r => `<div>${r.test_name}: ${r.value} (${r.date})</div>`).join('');
+}
+
+document.getElementById('filter-lab-results').addEventListener('click', loadLabResults);

--- a/backend/db.js
+++ b/backend/db.js
@@ -18,6 +18,13 @@ if (process.env.NODE_ENV === 'test') {
       last_name TEXT NOT NULL,
       pesel TEXT NOT NULL
     );
+    CREATE TABLE lab_results (
+      id SERIAL PRIMARY KEY,
+      patient_id INTEGER REFERENCES patients(id) ON DELETE CASCADE,
+      test_name TEXT NOT NULL,
+      date DATE NOT NULL,
+      value TEXT NOT NULL
+    );
   `);
   const adapter = db.adapters.createPg();
   pool = new adapter.Pool();

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,11 @@ const { body, validationResult } = require('express-validator');
 const cors = require('cors');
 const pool = require('./db');
 const auth = require('./middleware');
+const multer = require('multer');
+const csvParse = require('csv-parse/sync');
+const xlsx = require('xlsx');
+
+const upload = multer({ storage: multer.memoryStorage() });
 
 const app = express();
 app.use(cors());
@@ -23,6 +28,13 @@ async function init() {
       first_name TEXT NOT NULL,
       last_name TEXT NOT NULL,
       pesel TEXT NOT NULL
+    );`);
+    await pool.query(`CREATE TABLE IF NOT EXISTS lab_results (
+      id SERIAL PRIMARY KEY,
+      patient_id INTEGER REFERENCES patients(id) ON DELETE CASCADE,
+      test_name TEXT NOT NULL,
+      date DATE NOT NULL,
+      value TEXT NOT NULL
     );`);
   }
   const hashed = await bcrypt.hash('admin123', 10);
@@ -70,6 +82,57 @@ app.post('/api/patients', auth, [
     [firstName, lastName, pesel]
   );
   res.status(201).json(result.rows[0]);
+});
+
+app.post('/api/lab-results/import', auth, upload.single('file'), async (req, res) => {
+  const { patientId } = req.body;
+  if (!patientId || !req.file) {
+    return res.status(400).json({ message: 'Brak danych' });
+  }
+  try {
+    let rows;
+    if (req.file.mimetype === 'text/csv' || req.file.originalname.endsWith('.csv')) {
+      const text = req.file.buffer.toString('utf8');
+      rows = csvParse.parse(text, { columns: true, skip_empty_lines: true });
+    } else {
+      const workbook = xlsx.read(req.file.buffer, { type: 'buffer' });
+      const sheetName = workbook.SheetNames[0];
+      rows = xlsx.utils.sheet_to_json(workbook.Sheets[sheetName]);
+    }
+    const promises = rows.map(r =>
+      pool.query(
+        'INSERT INTO lab_results (patient_id, test_name, date, value) VALUES ($1, $2, $3, $4)',
+        [patientId, r.testName || r.test_name, r.date, r.value]
+      )
+    );
+    await Promise.all(promises);
+    res.json({ inserted: rows.length });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: 'Niepoprawny plik' });
+  }
+});
+
+app.get('/api/lab-results', auth, async (req, res) => {
+  const { patientId, testName, from, to } = req.query;
+  if (!patientId) return res.status(400).json({ message: 'patientId required' });
+  let query = 'SELECT test_name, date, value FROM lab_results WHERE patient_id=$1';
+  const params = [patientId];
+  if (testName) {
+    params.push(testName);
+    query += ` AND test_name=$${params.length}`;
+  }
+  if (from) {
+    params.push(from);
+    query += ` AND date >= $${params.length}`;
+  }
+  if (to) {
+    params.push(to);
+    query += ` AND date <= $${params.length}`;
+  }
+  query += ' ORDER BY date DESC';
+  const result = await pool.query(query, params);
+  res.json(result.rows);
 });
 
 module.exports = { app, init };

--- a/index.html
+++ b/index.html
@@ -142,6 +142,12 @@
                             <h3><i class="fas fa-flask"></i> Wyniki badań laboratoryjnych</h3>
                         </div>
                         <div class="card__body">
+                            <div class="lab-filter">
+                                <input type="text" id="filter-test-name" class="form-control" placeholder="Nazwa badania">
+                                <input type="date" id="filter-from-date" class="form-control">
+                                <input type="date" id="filter-to-date" class="form-control">
+                                <button type="button" id="filter-lab-results" class="btn btn--outline btn--sm">Filtruj</button>
+                            </div>
                             <div id="lab-results" class="lab-results"></div>
                         </div>
                     </div>
@@ -257,11 +263,15 @@
                                 <option value="">Wybierz pacjenta</option>
                             </select>
                         </div>
-                        <div class="form-group">
+                         <div class="form-group">
                             <label for="import-test-name" class="form-label">Nazwa badania</label>
                             <input type="text" id="import-test-name" class="form-control" placeholder="np. Morfologia, Biochemia">
-                        </div>
-                        <div class="form-group">
+                         </div>
+                         <div class="form-group">
+                             <label for="lab-file" class="form-label">Plik CSV/XLSX</label>
+                             <input type="file" id="lab-file" class="form-control" accept=".csv,.xlsx">
+                         </div>
+                         <div class="form-group">
                             <label class="form-label">Wyniki badań</label>
                             <div id="lab-import-table" class="lab-import-table">
                                 <table class="results-table">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "bcrypt": "^5.1.0",
         "cors": "^2.8.5",
+        "csv-parse": "^5.5.0",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
-        "pg": "^8.11.3"
+        "multer": "^1.4.5-lts.1",
+        "pg": "^8.11.3",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -1164,6 +1167,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1253,6 +1265,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/aproba": {
       "version": "2.1.0",
@@ -1550,8 +1568,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1651,6 +1679,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1736,6 +1777,15 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -1808,6 +1858,57 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1864,6 +1965,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -1875,6 +1982,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-jest": {
@@ -1913,6 +2032,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -2435,6 +2560,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -4018,6 +4152,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -4092,6 +4235,37 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
+      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4707,6 +4881,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5199,6 +5379,18 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -5219,6 +5411,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -5514,6 +5714,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
@@ -5660,6 +5866,24 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -5696,6 +5920,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "multer": "^1.4.5-lts.1",
+    "csv-parse": "^5.5.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- add CSV/XLSX upload field and filtering controls for lab results in UI
- implement backend endpoints to parse spreadsheets and store lab results
- load and filter patient lab results via new frontend logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979b7e9f14832eb5a3acd14afbff30