### PR TITLE
Add role-based patient access and medical history CRUD

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 // Prosty frontend korzystający z backendu Express
 let token = null;
 let currentPatientId = null;
+let permissions = {};
 
 async function login(e) {
   e.preventDefault();
@@ -18,8 +19,12 @@ async function login(e) {
     return;
   }
   token = data.token;
+  permissions = data.permissions || {};
   document.getElementById('login-page').classList.add('hidden');
   document.getElementById('main-app').classList.remove('hidden');
+  if (permissions.canAddPatient) document.getElementById('nav-add-patient').classList.remove('hidden');
+  if (permissions.canAddLabResult) document.getElementById('nav-import-lab').classList.remove('hidden');
+  if (permissions.isAdmin) document.getElementById('nav-admin').classList.remove('hidden');
   loadPatients();
 }
 
@@ -44,9 +49,9 @@ async function loadPatients() {
       document.getElementById('dashboard-section').classList.remove('active');
       document.getElementById('patient-profile-section').classList.add('active');
       document.getElementById('patient-name').textContent = card.getAttribute('data-name');
-      document.getElementById('add-record-btn').classList.remove('hidden');
-      document.getElementById('add-comment-btn').classList.remove('hidden');
-      document.getElementById('add-lab-result-btn').classList.remove('hidden');
+      if (permissions.canAddRecord) document.getElementById('add-record-btn').classList.remove('hidden');
+      if (permissions.canAddComment) document.getElementById('add-comment-btn').classList.remove('hidden');
+      if (permissions.canAddLabResult) document.getElementById('add-lab-result-btn').classList.remove('hidden');
       loadMedicalRecords();
       loadLabResults();
       loadComments();

--- a/backend/db.js
+++ b/backend/db.js
@@ -10,13 +10,23 @@ if (process.env.NODE_ENV === 'test') {
       id SERIAL PRIMARY KEY,
       username TEXT UNIQUE NOT NULL,
       password TEXT NOT NULL,
-      role TEXT NOT NULL
+      role TEXT NOT NULL,
+      patient_access INTEGER[] DEFAULT '{}'::INTEGER[]
     );
     CREATE TABLE patients (
       id SERIAL PRIMARY KEY,
       first_name TEXT NOT NULL,
       last_name TEXT NOT NULL,
       pesel TEXT NOT NULL
+    );
+    CREATE TABLE medical_records (
+      id SERIAL PRIMARY KEY,
+      patient_id INTEGER REFERENCES patients(id) ON DELETE CASCADE,
+      date DATE NOT NULL,
+      type TEXT NOT NULL,
+      description TEXT NOT NULL,
+      diagnosis TEXT,
+      treatment TEXT
     );
     CREATE TABLE lab_results (
       id SERIAL PRIMARY KEY,

--- a/backend/middleware.js
+++ b/backend/middleware.js
@@ -1,12 +1,43 @@
 const jwt = require('jsonwebtoken');
 
-module.exports = function(req, res, next) {
-  const auth = req.headers['authorization'];
-  if (!auth) return res.status(401).json({message: 'Brak tokena'});
-  const token = auth.split(' ')[1];
+function auth(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) return res.status(401).json({ message: 'Brak tokena' });
+  const token = authHeader.split(' ')[1];
   jwt.verify(token, process.env.JWT_SECRET || 'sekret', (err, user) => {
-    if (err) return res.status(403).json({message: 'Nieprawidłowy token'});
+    if (err) return res.status(403).json({ message: 'Nieprawidłowy token' });
     req.user = user;
     next();
   });
-};
+}
+
+function permit(action) {
+  return (req, res, next) => {
+    const { role, patientAccess } = req.user;
+    const id = parseInt(
+      req.params.id ||
+      req.params.patientId ||
+      req.query.patientId ||
+      req.body.patientId
+    );
+    const isAdmin = role === 'admin';
+    const canWrite = ['admin', 'doctor', 'nurse'].includes(role);
+    const canRead = canWrite || role === 'viewer';
+
+    if (action === 'write' && !canWrite) {
+      return res.status(403).json({ message: 'Brak uprawnień' });
+    }
+    if (action === 'read' && !canRead) {
+      return res.status(403).json({ message: 'Brak uprawnień' });
+    }
+    if (id && !isAdmin) {
+      const access = Array.isArray(patientAccess) ? patientAccess : [];
+      if (!access.includes(id)) {
+        return res.status(403).json({ message: 'Brak dostępu do pacjenta' });
+      }
+    }
+    next();
+  };
+}
+
+module.exports = { auth, permit };

--- a/index.html
+++ b/index.html
@@ -76,10 +76,10 @@
                 <button id="nav-dashboard" class="nav-btn active">
                     <i class="fas fa-tachometer-alt"></i> Dashboard
                 </button>
-                <button id="nav-add-patient" class="nav-btn">
+                <button id="nav-add-patient" class="nav-btn hidden">
                     <i class="fas fa-user-plus"></i> Dodaj Pacjenta
                 </button>
-                <button id="nav-import-lab" class="nav-btn">
+                <button id="nav-import-lab" class="nav-btn hidden">
                     <i class="fas fa-file-import"></i> Import Badań
                 </button>
                 <button id="nav-admin" class="nav-btn hidden">


### PR DESCRIPTION
## Summary
- Add auth middleware enforcing roles and patient access lists
- Implement CRUD endpoints for patients and medical records with permission checks
- Expose permissions to frontend and toggle UI elements based on backend response

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897cf7bd20c832e86a56ebbf18835b0